### PR TITLE
fixup metrics name for cpu load avgs, refs PR #20.  Results in the fo…

### DIFF
--- a/server/routes/formatter.js
+++ b/server/routes/formatter.js
@@ -11,9 +11,9 @@ export default function (info) {
     metrics['kibana_concurrent_connections'] = info.metrics.concurrent_connections || 0;
     metrics['kibana_requests_total'] = info.metrics.requests.total || 0;
     metrics['kibana_requests_disconnects'] = info.metrics.disconnects || 0;
-    metrics['kibana_os_cpu_load_average{interval="1m"}'] = info.metrics.os.cpu.load_average['1m'] || 0;
-    metrics['kibana_os_cpu_load_average{interval="5m"}'] = info.metrics.os.cpu.load_average['5m'] || 0;
-    metrics['kibana_os_cpu_load_average{interval="15m"}'] = info.metrics.os.cpu.load_average['15m'] || 0;
+    metrics['kibana_os_cpu_load_average_1m'] = info.metrics.os.cpu.load_average['1m'] || 0;
+    metrics['kibana_os_cpu_load_average_5m'] = info.metrics.os.cpu.load_average['5m'] || 0;
+    metrics['kibana_os_cpu_load_average_15m'] = info.metrics.os.cpu.load_average['15m'] || 0;
 
     for(var key in info.status.statuses) {
         let plugin_name = info.status.statuses[key]['id'].split(/:|@/)[1];


### PR DESCRIPTION
…llowing error when scrapped by prometheus err="invalid metric type \"interval=\\\"1m\\\"} gauge\""