### PR TITLE
Problem with required kibana version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Prometheus metrics for Kibana",
   "main": "index.js",
   "kibana": {
-    "version": "7.1.1",
+    "version": "7.7.1",
     "templateVersion": "8.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Plugin installation was unsuccessful due to error "Plugin kibana-prometheus-exporter [7.1.1] is incompatible with Kibana [7.7.1]"