### PR TITLE
fix(7.10): make it work with kibana 7.10

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -9,14 +9,19 @@ export function defineRoutes(router: IRouter) {
       validate: false,
     },
     async (context, request, response) => {
+      let reqHeaders = {};
+      let reqHost = request.url.host || '127.0.0.1';
+      let reqPort = request.url.port || '5601';
+      let reqProto = request.url.protocol || 'http';
+      let reqUrl = `${reqProto}://${reqHost}:${reqPort}/api/status`;
+
+      if (request.headers !== undefined
+          && request.headers.authorization !== undefined) {
+        reqHeaders = { 'Authorization': request.headers.authorization };
+      }
 
       const kibanaInternalStatus = await axios.get(
-        `${request.url.protocol}//${request.url.host}/api/status`,
-        {
-          headers: {
-            'Authorization': request.headers.authorization
-          }
-        }
+        reqUrl, { headers: reqHeaders }
       );
       
       const prometheusStats = formatter(kibanaInternalStatus.data);


### PR DESCRIPTION
tested against 7.10.2

might help with #201 , #204 , #205 , #207 

fixes the URL queried (missing semicolon & port). make the authorization header optional.

Not certain all the values returned are actually correct.
uptime, cpu usage or heap max/usage look allright. considering that plugin doesn't seem to rewrite anything, that's probably a good sign ...

Checking your dashboard, I noticed the `kibana_plugin_kibana_prometheus_exporter` is now called `kibana_plugin_kibanaPrometheusExporter` -- though it could be something wrong with the way I built the plugin, the zip file containers a folder `kibanaPrometheusExporter`.